### PR TITLE
Add a custom errorHandler

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,16 +15,26 @@ import {
 } from "redux-saga/effects";
 
 /**
+ * The default error handler which calls `console.error`
+ * 调用`console.error`的默认错误处理程序
+ * @param {Error} error
+ */
+const defaultErrorHandler = function(error) {
+  console.error("Error caught by redux-saga-catch: ", error);
+};
+
+/**
  * Quick wrap a saga with `try catch`
  * 快速使用try catch包装saga
  * @param {Saga} saga
+ * @param {Function} [errorHandler=defaultErrorHandler]
  */
-export function tryCatch(saga) {
+export function tryCatch(saga, errorHandler = defaultErrorHandler) {
   const wrapped = function* wrappedTryCatch() {
     try {
       yield call(saga, ...arguments);
     } catch (e) {
-      console.error("Error caught by redux-saga-catch: ", e);
+      errorHandler(e);
     }
   };
   /** For debug trace. 用于调试时跟踪原始代码 */
@@ -73,11 +83,12 @@ export function throttle(ms, pattern, worker, ...args) {
  * usage/用法:
  * yield parallel([function*(){}, ...sagas])
  * @param {Saga[]} sagas
+ * @param {Function} [errorHandler=defaultErrorHandler]
  */
-export function parallel(sagas) {
+export function parallel(sagas, errorHandler = defaultErrorHandler) {
   return call(function*(sagas) {
     for (let i = 0; i < sagas.length; i++) {
-      yield fork(tryCatch(sagas[i]));
+      yield fork(tryCatch(sagas[i], errorHandler));
     }
   }, sagas);
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 /**
  * Helper for redux-saga, auto wrap saga with try-catch, prevent one throw stop all.
  * redux-saga工具集，为了业务健壮，自动将saga进行try-catch包装，避免一个出错导致其它saga也出错中止。
- * 
+ *
  * @author cyrilluce@gmail.com
  */
 import {
@@ -17,7 +17,7 @@ import {
 /**
  * Quick wrap a saga with `try catch`
  * 快速使用try catch包装saga
- * @param {Saga} saga 
+ * @param {Saga} saga
  */
 export function tryCatch(saga) {
   const wrapped = function* wrappedTryCatch() {
@@ -35,9 +35,9 @@ export function tryCatch(saga) {
 /**
  * Like saga's takeEvery, but swallow exception and don't cancel the takeEveryHelper.
  * 类似于saga原生的takeEvery，但是出错也不会导致监听中止
- * @param {*} pattern 
- * @param {Saga} worker 
- * @param {*} args 
+ * @param {*} pattern
+ * @param {Saga} worker
+ * @param {*} args
  */
 export function takeEvery(pattern, worker, ...args) {
   return _takeEvery(pattern, tryCatch(worker), ...args);
@@ -46,9 +46,9 @@ export function takeEvery(pattern, worker, ...args) {
 /**
  * Like saga's takeLatest, but swallow exception and don't cancel the takeLatestHelper.
  * 类似于saga原生的takeLatest，但是出错也不会导致监听中止
- * @param {*} pattern 
- * @param {Saga} worker 
- * @param {*} args 
+ * @param {*} pattern
+ * @param {Saga} worker
+ * @param {*} args
  */
 export function takeLatest(pattern, worker, ...args) {
   return _takeLatest(pattern, tryCatch(worker), ...args);
@@ -57,10 +57,10 @@ export function takeLatest(pattern, worker, ...args) {
 /**
  * Like saga's throttle, but swallow exception and don't cancel the throttleHelper.
  * 类似于saga原生的throttle，但是出错也不会导致监听中止
- * @param {*} ms 
- * @param {*} pattern 
- * @param {Saga} worker 
- * @param {*} args 
+ * @param {*} ms
+ * @param {*} pattern
+ * @param {Saga} worker
+ * @param {*} args
  */
 export function throttle(ms, pattern, worker, ...args) {
   return _throttle(ms, pattern, tryCatch(worker), ...args);
@@ -69,10 +69,10 @@ export function throttle(ms, pattern, worker, ...args) {
 /**
  * run child sagas parallel, and child saga's exception don't cancel current saga.
  * 并行执行多个子saga，并且子saga出错不会影响父saga以及其它同级saga。
- * 
+ *
  * usage/用法:
  * yield parallel([function*(){}, ...sagas])
- * @param {Saga[]} sagas 
+ * @param {Saga[]} sagas
  */
 export function parallel(sagas) {
   return call(function*(sagas) {
@@ -87,9 +87,9 @@ export function parallel(sagas) {
  * 与takeLatest相似，但会先fork执行一次saga。
  * takeLatest:  while( pattern ){ saga }
  * runAndTakeLatest:  do{ saga }while( pattern )
- * @param {*} pattern 
- * @param {*} saga 
- * @param {*} args 
+ * @param {*} pattern
+ * @param {*} saga
+ * @param {*} args
  */
 export function runAndTakeLatest(pattern, saga, ...args) {
   saga = tryCatch(saga);


### PR DESCRIPTION
When a saga fails, we want to be able to supply a custom errorHandler so that we can link to error
reporting services.

This also contains some minor linting improvements (white space removed) enforced by Prettier.